### PR TITLE
Fix spinner residual job output in claude-use scripts

### DIFF
--- a/bin/claude-use.bash
+++ b/bin/claude-use.bash
@@ -35,6 +35,7 @@ _cu_with_spinner() {
     done
   } &
   local spid=$!
+  disown "$spid" 2>/dev/null || true
   "$@"
   local ret=$?
   kill "$spid" 2>/dev/null

--- a/bin/claude-use.zsh
+++ b/bin/claude-use.zsh
@@ -33,7 +33,7 @@ _cu_with_spinner() {
       i=$(( i % ${#frames} + 1 ))
       sleep 0.1
     done
-  } &
+  } &!
   local spid=$!
   "$@"
   local ret=$?


### PR DESCRIPTION
## Summary
- prevent spinner background job messages in zsh by disowning with `&!`
- disown spinner process in bash version to avoid job control output

## Testing
- `bash tests/run-tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68c79fbbaa88832a84299a03712b59a2